### PR TITLE
Update hosts.py

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -297,7 +297,7 @@ def _write_hosts(hosts):
             if ip.startswith('comment'):
                 line = ''.join(aliases)
             else:
-                line = '{0}\t\t{1}'.format(
+                line = '{0}  {1}'.format(
                     ip,
                     ' '.join(aliases)
                     )


### PR DESCRIPTION
removing the \t tabs from the host file . This is causing a issue under https://github.com/saltstack/salt/issues/54413

### What does this PR do?
Using hosts.add_host all the entry in /etc/hosts are separated by using 2 tab characters. Checking hosts' man entry:
Fields of the entry are separated by any number of blanks and/or tab characters.

This creates issues if a directive like $include is used inside the /etc/hosts file. By using tabs that directive does not work.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/54413## Previous Behavior

### Tests written?

yes , I confirm the issue has been resolve and double spacing is being used. 
